### PR TITLE
Default the username and ssh cidr

### DIFF
--- a/marketplace/261a9b6d-4be2-40b3-bb5f-80930a4a9570.e31cfd6b-5034-45ec-90b3-c559d06bbc65.template
+++ b/marketplace/261a9b6d-4be2-40b3-bb5f-80930a4a9570.e31cfd6b-5034-45ec-90b3-c559d06bbc65.template
@@ -29,7 +29,8 @@
     },
     "Username": {
       "Description": "Username for Couchbase administrator",
-      "Type": "String"
+      "Type": "String",
+      "Default": "Administrator",
     },
     "Password": {
       "Description": "Password for Couchbase administrator",
@@ -43,6 +44,7 @@
     "SSHCIDR": {
       "Description": "SSH CIDR",
       "Type": "String",
+      "Default": "0.0.0.0/0",
       "MinLength": 9,
       "MaxLength": 18,
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",


### PR DESCRIPTION
- Default the username to Administrator (inline w/ Couchbase Server UI AFAIK)
- Default SSH CIDR to all IP's, which will make it more accessible to less advanced users

If thumbs up, I'll update the PR to include all the relevant cloudformation templates